### PR TITLE
Upgrade the hamcrest dependency to version 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .classpath
 .project
 
+# IDEA Files #
+.idea
+
 # Package Files #
 *.jar
 *.war

--- a/pom.xml
+++ b/pom.xml
@@ -43,34 +43,27 @@
 		</developer>
 	</developers>
 
+	<properties>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>1.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.hamcrest</groupId>
-					<artifactId>hamcrest-core</artifactId>
-				</exclusion>
-			</exclusions>
+			<artifactId>hamcrest</artifactId>
+			<version>2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
-			<version>6.8.7</version>
+			<version>7.7.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -82,7 +75,7 @@
 		<dependency>
 			<groupId>org.exparity</groupId>
 			<artifactId>fluent-date</artifactId>
-			<version>1.0.1</version>
+			<version>2.0.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -90,17 +83,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.1.2</version>
+				<version>3.3.0</version>
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -110,7 +95,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.1</version>
+				<version>3.5.0</version>
 				<configuration>
 					<additionalparam>-Xdoclint:none</additionalparam>
 					<source>8</source>

--- a/src/main/java/org/exparity/hamcrest/date/DateMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/DateMatchers.java
@@ -51,13 +51,16 @@ import org.exparity.hamcrest.date.core.types.Interval;
  *
  * @author Stewart Bissett
  */
-public abstract class DateMatchers {
-	
+public final class DateMatchers {
+
+    private DateMatchers(){}
+
 	public static final String UNSUPPORTED_SQL_DATE_UNIT = "java.sql.Date does not support time-based comparisons. Prefer SqlDateMatchers for java.sql.Date appropriate matchers";
 	
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -71,8 +74,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -86,8 +90,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -103,8 +108,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -118,8 +124,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -133,8 +140,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -148,8 +156,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -167,8 +176,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -184,8 +194,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -211,8 +222,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -236,8 +248,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -251,8 +264,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -266,8 +280,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -283,8 +298,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -298,8 +314,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -313,8 +330,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -328,8 +346,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -347,8 +366,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -364,8 +384,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -391,8 +412,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -416,8 +438,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -431,8 +454,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -446,8 +470,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -463,8 +488,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -478,8 +504,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the week as any of the supplied days
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -493,8 +520,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -508,8 +536,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the expected day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -523,8 +552,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -538,8 +568,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -553,8 +584,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -570,8 +602,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -585,8 +618,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -604,8 +638,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -621,8 +656,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same hour as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -649,8 +685,9 @@ public abstract class DateMatchers {
     }
 	
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same hour as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -669,13 +706,15 @@ public abstract class DateMatchers {
 	 * @param date the reference date against which the examined date is checked
 	 * @throws TemporalConversionException
 	 */
+    @Deprecated
     public static TemporalMatcher<Date> sameHourOfDay(final java.sql.Date date) {
     	throw new TemporalConversionException(UNSUPPORTED_SQL_DATE_UNIT);
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same hour as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -691,8 +730,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same hour as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -706,8 +746,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same instant as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -732,9 +773,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same UTC instant as the reference Instant
      * supplied
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -748,9 +790,10 @@ public abstract class DateMatchers {
     }
 	
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same UTC instant as the reference UTC epoch time
      * supplied
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -764,8 +807,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same instance as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -793,8 +837,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same instance as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -822,8 +867,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -837,8 +883,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -852,8 +899,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -867,8 +915,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -882,8 +931,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is at the same date or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -899,9 +949,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -919,9 +970,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -937,9 +989,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same second or before the start of the reference
      * date and time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -965,9 +1018,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same second or before the start of the reference
      * date and time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -991,8 +1045,9 @@ public abstract class DateMatchers {
     }
 
     /**
-     * F Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+     * </p>
      * For example:
      *
      * <pre>
@@ -1006,8 +1061,9 @@ public abstract class DateMatchers {
     }
 
     /**
-     * F Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+     * </p>
      * For example:
      *
      * <pre>
@@ -1021,8 +1077,9 @@ public abstract class DateMatchers {
     }
     
     /**
-     * F Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+     * </p>
      * For example:
      *
      * <pre>
@@ -1036,8 +1093,9 @@ public abstract class DateMatchers {
     }
 
     /**
-     * F Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+     * </p>
      * For example:
      *
      * <pre>
@@ -1051,8 +1109,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1068,8 +1127,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1079,7 +1139,7 @@ public abstract class DateMatchers {
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
      * @param dayOfMonth the day of the month against which the examined date is checked
-     * @deprecated Use {@link #sameOrAfter(int, Month, int)
+     * @deprecated Use {@link #sameOrAfter(int, Month, int)}
      */
     @Deprecated
     public static TemporalMatcher<Date> sameOrAfter(final int year, final Months month, final int dayOfMonth) {
@@ -1087,8 +1147,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1104,9 +1165,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same second or after the start of the reference
      * date and time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1132,9 +1194,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same second or after the start of the reference
      * date and time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1158,8 +1221,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same minute as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1186,8 +1250,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same minute as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1212,8 +1277,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the reference minute
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1229,8 +1295,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the reference minute
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1244,8 +1311,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1261,8 +1329,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1278,8 +1347,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1293,8 +1363,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1308,8 +1379,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same month as the reference month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1325,8 +1397,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same month as the reference month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1342,8 +1415,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same second as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1370,8 +1444,9 @@ public abstract class DateMatchers {
 	}
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same second as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1396,8 +1471,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the reference second
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1413,8 +1489,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the reference second
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1428,8 +1505,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same millisecond as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1456,8 +1534,9 @@ public abstract class DateMatchers {
     }
 	
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same millisecond as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1482,8 +1561,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the reference second
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1499,8 +1579,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the reference second
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1514,8 +1595,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1529,8 +1611,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1544,8 +1627,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the same year as the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1559,8 +1643,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1576,8 +1661,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1591,8 +1677,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1608,8 +1695,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1623,8 +1711,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1638,8 +1727,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1653,8 +1743,9 @@ public abstract class DateMatchers {
     }
     
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1670,8 +1761,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a given period of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1695,8 +1787,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a given period of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1718,8 +1811,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a given period of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1751,8 +1845,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is within a given period of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1782,8 +1877,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is yesterday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1795,8 +1891,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is today
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1808,8 +1905,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is tomorrow
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1821,8 +1919,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a monday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1834,8 +1933,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a tuesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1847,8 +1947,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a wednesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1860,8 +1961,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a thursday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1873,8 +1975,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a friday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1886,8 +1989,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a saturday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1899,8 +2003,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a sunday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1912,8 +2017,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a weekday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1925,8 +2031,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on a weekend
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1938,8 +2045,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1951,9 +2059,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1967,8 +2076,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1980,9 +2090,10 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -1996,8 +2107,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in the expected month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2009,8 +2121,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in January
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2022,8 +2135,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in February
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2035,8 +2149,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in March
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2048,8 +2163,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in April
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2061,8 +2177,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in May
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2074,8 +2191,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in June
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2087,8 +2205,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in July
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2100,8 +2219,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in August
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2113,8 +2233,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in September
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2126,8 +2247,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in October
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2139,8 +2261,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in November
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2152,8 +2275,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is in December
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -2165,8 +2289,9 @@ public abstract class DateMatchers {
     }
 
     /**
+     * <p> 
      * Creates a matcher that matches when the examined date is a leap year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>

--- a/src/main/java/org/exparity/hamcrest/date/InstantMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/InstantMatchers.java
@@ -38,18 +38,20 @@ import org.exparity.hamcrest.date.core.IsYear;
 import org.exparity.hamcrest.date.core.TemporalConverters;
 import org.exparity.hamcrest.date.core.TemporalMatcher;
 import org.exparity.hamcrest.date.core.types.Interval;
-import org.hamcrest.Factory;
+
 
 /**
  * Static factory for creating {@link org.hamcrest.Matcher} instances for comparing {@link ZonedDateTime} instances
  *
  * @author Stewart Bissett
  */
-public abstract class InstantMatchers {
+public final class InstantMatchers {
 
+    private InstantMatchers(){}
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -63,8 +65,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -91,8 +94,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -106,8 +110,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -134,8 +139,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -149,8 +155,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -164,8 +171,9 @@ public abstract class InstantMatchers {
     }
     
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -181,8 +189,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -198,8 +207,9 @@ public abstract class InstantMatchers {
     }
     
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -213,8 +223,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same specified instance down to the second
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -242,8 +253,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -257,9 +269,10 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -275,7 +288,6 @@ public abstract class InstantMatchers {
      * @param nanos the nanosecond of the second
      * @param tz the time zone of the date to check against
      */
-    @Factory
     public static TemporalMatcher<Instant> sameOrBefore(final int year,
             final Month month,
             final int day,
@@ -288,8 +300,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -303,9 +316,10 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -321,7 +335,6 @@ public abstract class InstantMatchers {
      * @param nanos the nanosecond of the second
      * @param tz the time zone of the date to check against
      */
-    @Factory
     public static TemporalMatcher<Instant> sameOrAfter(final int year,
             final Month month,
             final int day,
@@ -334,8 +347,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -349,8 +363,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -364,8 +379,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -379,8 +395,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -394,8 +411,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same year as the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -409,8 +427,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -429,8 +448,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is within a given period of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -464,8 +484,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is yesterday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -477,8 +498,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is today
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -490,8 +512,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is tomorrow
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -503,8 +526,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -518,8 +542,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -531,8 +556,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as any of the supplied days
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -544,8 +570,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a monday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -557,8 +584,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a tuesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -570,8 +598,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a wednesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -583,8 +612,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a thursday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -596,8 +626,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a friday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -609,8 +640,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a saturday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -622,8 +654,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a sunday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -635,8 +668,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a weekday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -648,8 +682,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a weekend
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -661,8 +696,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -674,9 +710,10 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -690,8 +727,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -703,9 +741,10 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -719,8 +758,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in the expected month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -732,8 +772,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in January
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -745,8 +786,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in February
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -758,8 +800,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in March
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -771,8 +814,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in April
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -784,8 +828,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in May
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -797,8 +842,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in June
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -810,8 +856,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in July
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -823,8 +870,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in August
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -836,8 +884,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in September
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -849,8 +898,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in October
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -862,8 +912,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in November
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -875,8 +926,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in December
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -888,8 +940,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is a leap year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -901,8 +954,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected hour (0-23)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -916,8 +970,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same hour as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -931,8 +986,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected minute (0-59)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -946,8 +1002,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same minute as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -961,8 +1018,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected second (0-59)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -976,8 +1034,9 @@ public abstract class InstantMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same second as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>

--- a/src/main/java/org/exparity/hamcrest/date/LocalDateMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/LocalDateMatchers.java
@@ -38,11 +38,14 @@ import org.exparity.hamcrest.date.core.types.Interval;
  *
  * @author Stewart Bissett
  */
-public abstract class LocalDateMatchers {
+public final class LocalDateMatchers {
+
+    private LocalDateMatchers(){}
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -56,8 +59,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -73,8 +77,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -88,8 +93,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -105,8 +111,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -120,8 +127,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -137,8 +145,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -152,9 +161,10 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -170,8 +180,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -185,8 +196,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -202,8 +214,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -217,8 +230,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -232,8 +246,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the expected day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -247,8 +262,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -262,8 +278,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same year as the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -277,8 +294,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -292,8 +310,9 @@ public abstract class LocalDateMatchers {
     }
     
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -307,8 +326,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is within a given period of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -330,8 +350,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is yesterday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -343,8 +364,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is today
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -356,8 +378,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is tomorrow
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -369,8 +392,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -384,8 +408,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a monday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -397,8 +422,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a monday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -410,8 +436,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a monday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -423,8 +450,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a tuesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -436,8 +464,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a wednesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -449,8 +478,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a thursday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -462,8 +492,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a friday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -475,8 +506,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a saturday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -488,8 +520,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a sunday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -501,8 +534,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a weekday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -514,8 +548,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on a weekend
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -527,8 +562,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -540,9 +576,10 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -556,8 +593,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -569,9 +607,10 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -585,8 +624,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in the expected month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -598,8 +638,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in January
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -611,8 +652,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in February
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -624,8 +666,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in March
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -637,8 +680,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in April
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -650,8 +694,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in May
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -663,8 +708,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in June
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -676,8 +722,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in July
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -689,8 +736,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in August
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -702,8 +750,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in September
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -715,8 +764,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in October
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -728,8 +778,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in November
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -741,8 +792,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is in December
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -754,8 +806,9 @@ public abstract class LocalDateMatchers {
     }
 
     /**
+     *<p>
      * Creates a matcher that matches when the examined date is a leap year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>

--- a/src/main/java/org/exparity/hamcrest/date/LocalDateTimeMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/LocalDateTimeMatchers.java
@@ -35,18 +35,21 @@ import org.exparity.hamcrest.date.core.IsSecond;
 import org.exparity.hamcrest.date.core.IsWithin;
 import org.exparity.hamcrest.date.core.IsYear;
 import org.exparity.hamcrest.date.core.types.Interval;
-import org.hamcrest.Factory;
 
 /**
  * Static factory for creating {@link org.hamcrest.Matcher} instances for comparing {@link LocalDateTime} instances
  *
  * @author Stewart Bissett
  */
-public abstract class LocalDateTimeMatchers {
+public final class LocalDateTimeMatchers {
+
+
+	private LocalDateTimeMatchers(){}
 
 	/**
-	 * Creates a matcher that matches when the examined date is after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -60,8 +63,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is after the end of the reference year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is after the end of the reference year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -85,8 +89,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -100,8 +105,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is before the end of the reference year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is before the end of the reference year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -125,8 +131,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -140,8 +147,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -155,8 +163,9 @@ public abstract class LocalDateTimeMatchers {
     }
 	
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -172,8 +181,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -187,8 +197,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same specified instance down to the second
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same specified instance down to the second
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -214,8 +225,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -229,9 +241,10 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
 	 * date
-	 * <p/>
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -245,7 +258,6 @@ public abstract class LocalDateTimeMatchers {
 	 * @param minute the minute of the hour
 	 * @param second the second of the minute
 	 */
-	@Factory
 	public static TemporalMatcher<LocalDateTime> sameOrBefore(final int year,
 	        final Month month,
 	        final int day,
@@ -256,8 +268,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -271,8 +284,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -296,8 +310,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same month as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same month as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -311,8 +326,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -326,8 +342,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the expected day of the month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the expected day of the month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -341,8 +358,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -356,8 +374,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same year as the reference year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same year as the reference year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -371,8 +390,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a defined period the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a defined period the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -388,8 +408,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a given period of the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a given period of the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -419,8 +440,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is yesterday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is yesterday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -432,8 +454,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is today
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is today
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -445,8 +468,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is tomorrow
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is tomorrow
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -458,8 +482,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -473,8 +498,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a monday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a monday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -486,8 +512,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a monday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a monday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -499,8 +526,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a monday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a monday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -512,8 +540,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a tuesday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a tuesday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -525,8 +554,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a wednesday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a wednesday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -538,8 +568,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a thursday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a thursday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -551,8 +582,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a friday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a friday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -564,8 +596,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a saturday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a saturday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -577,8 +610,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a sunday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a sunday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -590,8 +624,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a weekday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a weekday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -603,8 +638,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a weekend
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a weekend
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -616,8 +652,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the first day of the month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the first day of the month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -629,9 +666,10 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
 	 * period
-	 * <p/>
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -645,8 +683,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the first day of the month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the first day of the month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -658,9 +697,10 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
 	 * period
-	 * <p/>
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -674,8 +714,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in the expected month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in the expected month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -687,8 +728,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in January
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in January
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -700,8 +742,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in February
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in February
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -713,8 +756,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in March
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in March
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -726,8 +770,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in April
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in April
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -739,8 +784,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in May
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in May
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -752,8 +798,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in June
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in June
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -765,8 +812,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in July
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in July
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -778,8 +826,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in August
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in August
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -791,8 +840,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in September
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in September
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -804,8 +854,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in October
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in October
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -817,8 +868,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in November
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in November
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -830,8 +882,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in December
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in December
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -843,8 +896,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is a leap year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is a leap year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -856,8 +910,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the expected hour (0-23)
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the expected hour (0-23)
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -871,8 +926,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same hour as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same hour as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -886,8 +942,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the expected minute (0-59)
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the expected minute (0-59)
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -901,8 +958,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same minute as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same minute as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -916,8 +974,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the expected second (0-59)
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the expected second (0-59)
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -931,8 +990,9 @@ public abstract class LocalDateTimeMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same second as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same second as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>

--- a/src/main/java/org/exparity/hamcrest/date/LocalTimeMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/LocalTimeMatchers.java
@@ -32,11 +32,14 @@ import org.hamcrest.Matcher;
  *
  * @author Stewart Bissett
  */
-public abstract class LocalTimeMatchers {
+public final class LocalTimeMatchers {
+
+    private LocalTimeMatchers(){}
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is after the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -50,8 +53,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -67,8 +71,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is before the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -82,8 +87,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -99,8 +105,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is at the same instant or before the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -114,9 +121,10 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is on the same day or before the start of the reference
      * time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -132,8 +140,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is at the same instant or after the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -147,8 +156,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is on the same day or after the start of the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -164,8 +174,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is within a defined period the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -179,8 +190,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is within a given period of the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -202,9 +214,10 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -218,9 +231,10 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -234,8 +248,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is on the expected hour (0-23)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -249,8 +264,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is on the same hour as the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -264,8 +280,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is on the expected minute (0-59)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -279,8 +296,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is on the same minute as the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -294,8 +312,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is on the expected second (0-59)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -309,8 +328,9 @@ public abstract class LocalTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined time is on the same second as the reference time
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>

--- a/src/main/java/org/exparity/hamcrest/date/OffsetDateTimeMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/OffsetDateTimeMatchers.java
@@ -36,18 +36,19 @@ import org.exparity.hamcrest.date.core.IsSecond;
 import org.exparity.hamcrest.date.core.IsWithin;
 import org.exparity.hamcrest.date.core.IsYear;
 import org.exparity.hamcrest.date.core.types.Interval;
-import org.hamcrest.Factory;
 
 /**
  * Static factory for creating {@link org.hamcrest.Matcher} instances for comparing {@link OffsetDateTime} instances
  *
  * @author Stewart Bissett
  */
-public abstract class OffsetDateTimeMatchers {
+public final class OffsetDateTimeMatchers {
 
+    private OffsetDateTimeMatchers(){}
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -61,8 +62,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -89,8 +91,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -104,8 +107,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -132,8 +136,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -147,8 +152,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -162,8 +168,9 @@ public abstract class OffsetDateTimeMatchers {
     }
     
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -179,8 +186,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -196,8 +204,9 @@ public abstract class OffsetDateTimeMatchers {
     }
     
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -211,8 +220,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same specified instance down to the second
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -240,8 +250,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -255,9 +266,10 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -273,7 +285,6 @@ public abstract class OffsetDateTimeMatchers {
      * @param nanos the nanosecond of the second
      * @param tz the time zone of the date to check against
      */
-    @Factory
     public static TemporalMatcher<OffsetDateTime> sameOrBefore(final int year,
             final Month month,
             final int day,
@@ -286,8 +297,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -301,9 +313,10 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -319,7 +332,6 @@ public abstract class OffsetDateTimeMatchers {
      * @param nanos the nanosecond of the second
      * @param tz the time zone of the date to check against
      */
-    @Factory
     public static TemporalMatcher<OffsetDateTime> sameOrAfter(final int year,
             final Month month,
             final int day,
@@ -332,8 +344,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -347,8 +360,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -362,8 +376,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -377,8 +392,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -392,8 +408,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same year as the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -407,8 +424,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -427,8 +445,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is within a given period of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -462,8 +481,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is yesterday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -475,8 +495,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is today
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -488,8 +509,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is tomorrow
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -501,8 +523,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -516,8 +539,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -529,8 +553,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as any of the supplied days
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -542,8 +567,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a monday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -555,8 +581,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a tuesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -568,8 +595,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a wednesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -581,8 +609,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a thursday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -594,8 +623,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a friday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -607,8 +637,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a saturday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -620,8 +651,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a sunday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -633,8 +665,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a weekday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -646,8 +679,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a weekend
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -659,8 +693,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -672,9 +707,10 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -688,8 +724,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -701,9 +738,10 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -717,8 +755,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in the expected month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -730,8 +769,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in January
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -743,8 +783,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in February
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -756,8 +797,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in March
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -769,8 +811,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in April
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -782,8 +825,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in May
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -795,8 +839,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in June
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -808,8 +853,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in July
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -821,8 +867,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in August
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -834,8 +881,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in September
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -847,8 +895,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in October
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -860,8 +909,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in November
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -873,8 +923,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in December
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -886,8 +937,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is a leap year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -899,8 +951,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected hour (0-23)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -914,8 +967,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same hour as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -929,8 +983,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected minute (0-59)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -944,8 +999,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same minute as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -959,8 +1015,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected second (0-59)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -974,8 +1031,9 @@ public abstract class OffsetDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same second as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>

--- a/src/main/java/org/exparity/hamcrest/date/SqlDateMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/SqlDateMatchers.java
@@ -39,11 +39,13 @@ import org.exparity.hamcrest.date.core.types.Interval;
  *
  * @author Stewart Bissett
  */
-public abstract class SqlDateMatchers {
+public final class SqlDateMatchers {
 
+	private SqlDateMatchers(){}
 	/**
-	 * Creates a matcher that matches when the examined date is after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -57,8 +59,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -72,8 +75,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -89,8 +93,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -104,8 +109,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is after the end of the reference year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is after the end of the reference year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -123,8 +129,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is after the end of the reference year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is after the end of the reference year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -140,8 +147,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -155,8 +163,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -170,8 +179,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -187,8 +197,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -202,8 +213,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is before the end of the reference year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is before the end of the reference year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -221,8 +233,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is before the end of the reference year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is before the end of the reference year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -238,8 +251,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -253,8 +267,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -268,8 +283,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -285,8 +301,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -300,8 +317,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the week as any of the supplied days
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the week as any of the supplied days
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -315,8 +333,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -330,8 +349,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -345,8 +365,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the expected day of the month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the expected day of the month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -360,8 +381,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -375,8 +397,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -392,8 +415,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -407,8 +431,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -426,8 +451,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -443,8 +469,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -458,8 +485,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -473,8 +501,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -488,8 +517,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same date or before the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same date or before the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -505,9 +535,10 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
 	 * date
-	 * <p/>
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -525,9 +556,10 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
 	 * date
-	 * <p/>
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -543,8 +575,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -558,8 +591,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -573,8 +607,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * F Creates a matcher that matches when the examined date is at the same instant or after the reference date
-	 * <p/>
+	 * <p>
+	 * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -588,8 +623,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is at the same instant or after the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -605,8 +641,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -616,7 +653,7 @@ public abstract class SqlDateMatchers {
 	 * @param year the year against which the examined date is checked
 	 * @param month the month against which the examined date is checked
 	 * @param dayOfMonth the day of the month against which the examined date is checked
-	 * @deprecated Use {@link #sameOrAfter(int, Month, int)
+	 * @deprecated Use {@link #sameOrAfter(int, Month, int)}
 	 */
 	@Deprecated
 	public static TemporalMatcher<java.sql.Date> sameOrAfter(final int year, final Months month, final int dayOfMonth) {
@@ -624,8 +661,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same day or after the start of the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -641,8 +679,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same month as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same month as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -658,8 +697,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same month as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same month as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -675,8 +715,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same month as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same month as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -686,12 +727,13 @@ public abstract class SqlDateMatchers {
 	 * @param date the reference date against which the examined date is checked
 	 */
 	public static TemporalMatcher<java.sql.Date> sameMonthOfYear(final Date date) {
-		return new IsMonth<Date>(SQLDATE_AS_MONTH, month(date));
+		return new IsMonth<>(SQLDATE_AS_MONTH, month(date));
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same month as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same month as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -705,8 +747,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same month as the reference month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same month as the reference month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -722,8 +765,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same month as the reference month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same month as the reference month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -739,8 +783,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -754,8 +799,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same year as the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same year as the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -769,8 +815,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the same year as the reference year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the same year as the reference year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -784,8 +831,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a defined period the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a defined period the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -801,8 +849,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a defined period the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a defined period the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -818,8 +867,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a defined period the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a defined period the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -833,8 +883,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a defined period the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a defined period the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -850,8 +901,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a defined period the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a defined period the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -865,8 +917,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a defined period the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a defined period the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -882,8 +935,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a given period of the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a given period of the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -907,8 +961,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is within a given period of the reference date
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is within a given period of the reference date
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -930,8 +985,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is yesterday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is yesterday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -943,8 +999,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is today
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is today
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -956,8 +1013,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is tomorrow
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is tomorrow
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -969,8 +1027,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a monday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a monday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -982,8 +1041,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a tuesday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a tuesday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -995,8 +1055,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a wednesday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a wednesday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1008,8 +1069,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a thursday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a thursday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1021,8 +1083,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a friday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a friday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1034,8 +1097,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a saturday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a saturday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1047,8 +1111,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a sunday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a sunday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1060,8 +1125,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a weekday
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a weekday
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1073,8 +1139,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on a weekend
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on a weekend
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1086,8 +1153,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the first day of the month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the first day of the month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1099,9 +1167,10 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
 	 * period
-	 * <p/>
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1115,8 +1184,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the first day of the month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the first day of the month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1128,9 +1198,10 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
+	 * <p>
+     * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
 	 * period
-	 * <p/>
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1144,8 +1215,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in the expected month
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in the expected month
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1159,8 +1231,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in January
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in January
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1172,8 +1245,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in February
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in February
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1185,8 +1259,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in March
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in March
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1198,8 +1273,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in April
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in April
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1211,8 +1287,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in May
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in May
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1224,8 +1301,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in June
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in June
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1237,8 +1315,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in July
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in July
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1250,8 +1329,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in August
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in August
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1263,8 +1343,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in September
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in September
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1276,8 +1357,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in October
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in October
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1289,8 +1371,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in November
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in November
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1302,8 +1385,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is in December
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is in December
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>
@@ -1315,8 +1399,9 @@ public abstract class SqlDateMatchers {
 	}
 
 	/**
-	 * Creates a matcher that matches when the examined date is a leap year
-	 * <p/>
+	 * <p>
+     * Creates a matcher that matches when the examined date is a leap year
+	 * </p>
 	 * For example:
 	 *
 	 * <pre>

--- a/src/main/java/org/exparity/hamcrest/date/ZonedDateTimeMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/ZonedDateTimeMatchers.java
@@ -1,52 +1,31 @@
 package org.exparity.hamcrest.date;
 
+import org.exparity.hamcrest.date.core.*;
+import org.exparity.hamcrest.date.core.types.Interval;
+
+import java.time.*;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+
 import static java.time.DayOfWeek.*;
 import static java.time.Month.*;
 import static org.exparity.hamcrest.date.core.TemporalConverters.*;
 import static org.exparity.hamcrest.date.core.TemporalFunctions.ZONEDDATETIME;
 import static org.exparity.hamcrest.date.core.TemporalProviders.*;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.Month;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
-import java.time.temporal.ChronoUnit;
-
-import org.exparity.hamcrest.date.core.TemporalMatcher;
-import org.exparity.hamcrest.date.core.IsAfter;
-import org.exparity.hamcrest.date.core.IsBefore;
-import org.exparity.hamcrest.date.core.IsDayOfMonth;
-import org.exparity.hamcrest.date.core.IsDayOfWeek;
-import org.exparity.hamcrest.date.core.IsFirstDayOfMonth;
-import org.exparity.hamcrest.date.core.IsHour;
-import org.exparity.hamcrest.date.core.IsLastDayOfMonth;
-import org.exparity.hamcrest.date.core.IsLeapYear;
-import org.exparity.hamcrest.date.core.IsMaximum;
-import org.exparity.hamcrest.date.core.IsMinimum;
-import org.exparity.hamcrest.date.core.IsMinute;
-import org.exparity.hamcrest.date.core.IsMonth;
-import org.exparity.hamcrest.date.core.IsSame;
-import org.exparity.hamcrest.date.core.IsSameDay;
-import org.exparity.hamcrest.date.core.IsSameOrAfter;
-import org.exparity.hamcrest.date.core.IsSameOrBefore;
-import org.exparity.hamcrest.date.core.IsSecond;
-import org.exparity.hamcrest.date.core.IsWithin;
-import org.exparity.hamcrest.date.core.IsYear;
-import org.exparity.hamcrest.date.core.types.Interval;
-import org.hamcrest.Factory;
-
 /**
  * Static factory for creating {@link org.hamcrest.Matcher} instances for comparing {@link ZonedDateTime} instances
  *
  * @author Stewart Bissett
  */
-public abstract class ZonedDateTimeMatchers {
+public final class ZonedDateTimeMatchers {
+
+    private ZonedDateTimeMatchers(){}
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -60,8 +39,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is after the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -88,8 +68,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -103,8 +84,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is before the end of the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -131,8 +113,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -146,8 +129,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -161,8 +145,9 @@ public abstract class ZonedDateTimeMatchers {
     }
     
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -178,8 +163,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -195,8 +181,9 @@ public abstract class ZonedDateTimeMatchers {
     }
     
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -210,8 +197,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same specified instance down to the second
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -239,8 +227,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant or before the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -254,9 +243,10 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -272,7 +262,6 @@ public abstract class ZonedDateTimeMatchers {
      * @param nanos the nanosecond of the second
      * @param tz the time zone of the date to check against
      */
-    @Factory
     public static TemporalMatcher<ZonedDateTime> sameOrBefore(final int year,
             final Month month,
             final int day,
@@ -285,8 +274,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is at the same instant or after the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -300,9 +290,10 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day or before the start of the reference
      * date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -318,7 +309,6 @@ public abstract class ZonedDateTimeMatchers {
      * @param nanos the nanosecond of the second
      * @param tz the time zone of the date to check against
      */
-    @Factory
     public static TemporalMatcher<ZonedDateTime> sameOrAfter(final int year,
             final Month month,
             final int day,
@@ -331,8 +321,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -346,8 +337,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the month as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -361,8 +353,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -376,8 +369,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same year as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -391,8 +385,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same year as the reference year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -406,8 +401,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is within a defined period the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -426,8 +422,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is within a given period of the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -461,8 +458,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is yesterday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -474,8 +472,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is today
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -487,8 +486,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is tomorrow
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -500,8 +500,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -515,8 +516,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -528,8 +530,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same day of the week as any of the supplied days
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -541,8 +544,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a monday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -554,8 +558,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a tuesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -567,8 +572,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a wednesday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -580,8 +586,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a thursday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -593,8 +600,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a friday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -606,8 +614,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a saturday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -619,8 +628,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a sunday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -632,8 +642,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a weekday
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -645,8 +656,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on a weekend
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -658,8 +670,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -671,9 +684,10 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -687,8 +701,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the first day of the month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -700,9 +715,10 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the maximum value of the given date part in its
      * period
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -716,8 +732,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in the expected month
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -729,8 +746,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in January
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -742,8 +760,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in February
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -755,8 +774,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in March
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -768,8 +788,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in April
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -781,8 +802,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in May
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -794,8 +816,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in June
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -807,8 +830,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in July
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -820,8 +844,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in August
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -833,8 +858,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in September
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -846,8 +872,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in October
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -859,8 +886,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in November
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -872,8 +900,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is in December
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -885,8 +914,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is a leap year
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -898,8 +928,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected hour (0-23)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -913,8 +944,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same hour as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -928,8 +960,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected minute (0-59)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -943,8 +976,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same minute as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -958,8 +992,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the expected second (0-59)
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>
@@ -973,8 +1008,9 @@ public abstract class ZonedDateTimeMatchers {
     }
 
     /**
+     * <p>
      * Creates a matcher that matches when the examined date is on the same second as the reference date
-     * <p/>
+     * </p>
      * For example:
      *
      * <pre>

--- a/src/main/java/org/exparity/hamcrest/date/core/TemporalConverters.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/TemporalConverters.java
@@ -24,33 +24,33 @@ import org.exparity.hamcrest.date.core.types.Second;
  * e.g. given a {@link LocalDate} returns the hour, or given a {@link java.sql.Date} returns a {@link LocalDate}.
  * No-operation conversions e.g. LocalDate to LocalDate are present to keep a consistent usage pattern in the
  * {@link TemporalMatcher} implementations.
- * </p>
+ * <p>
  * The temporal converters generally "down-cast" a temporal type to another and are used to support testing the actual
  * type against the reference type where the reference type is an equal or less accurate temporal unit e.g. comparing if
  * a LocalDateTime is on a given year. There should not be "up-casting" converters because these would be making up
- * absent information e.g. converting a {@link LocalDate} to a {@link LocalDateTime}
+ * absent information e.g. converting a {@link LocalDate} to a {@link LocalDateTime}</p>
  */
-public class TemporalConverters {
+public final class TemporalConverters {
     
-    private TemporalConverters() {};
+    private TemporalConverters() {}
 
 	public static final String UNSUPPORTED_SQL_DATE_UNIT = "java.sql.Date does not support time-based comparisons. Prefer SqlDateMatchers for java.sql.Date appropriate matchers";
 	
 	/**
 	 * SQL Date Converters
 	 */
-	public static TemporalConverter<java.sql.Date, LocalDate> SQLDATE_AS_LOCALDATE = (date, zone) -> date.toLocalDate();
-	public static TemporalConverter<java.sql.Date, java.sql.Date> SQLDATE_AS_SQLDATE = (date, zone) -> date;
-	public static TemporalConverter<java.sql.Date, Year> SQLDATE_AS_YEAR = (date, zone) -> Year.from(SQLDATE_AS_LOCALDATE.apply(date, zone));
-	public static TemporalConverter<java.sql.Date, Month> SQLDATE_AS_MONTH = (date, zone) -> SQLDATE_AS_LOCALDATE.apply(date, zone).getMonth();
-	public static TemporalConverter<java.sql.Date, DayOfMonth> SQLDATE_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(SQLDATE_AS_LOCALDATE.apply(date, zone));
-	public static TemporalConverter<java.sql.Date, DayOfWeek> SQLDATE_AS_DAYOFWEEK = (date, zone) -> SQLDATE_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
+	public static final TemporalConverter<java.sql.Date, LocalDate> SQLDATE_AS_LOCALDATE = (date, zone) -> date.toLocalDate();
+	public static final TemporalConverter<java.sql.Date, java.sql.Date> SQLDATE_AS_SQLDATE = (date, zone) -> date;
+	public static final TemporalConverter<java.sql.Date, Year> SQLDATE_AS_YEAR = (date, zone) -> Year.from(SQLDATE_AS_LOCALDATE.apply(date, zone));
+	public static final TemporalConverter<java.sql.Date, Month> SQLDATE_AS_MONTH = (date, zone) -> SQLDATE_AS_LOCALDATE.apply(date, zone).getMonth();
+	public static final TemporalConverter<java.sql.Date, DayOfMonth> SQLDATE_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(SQLDATE_AS_LOCALDATE.apply(date, zone));
+	public static final TemporalConverter<java.sql.Date, DayOfWeek> SQLDATE_AS_DAYOFWEEK = (date, zone) -> SQLDATE_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
 
 	/**
 	 * Java Date Converters
 	 */
 
-	public static TemporalConverter<Date, Instant> JAVADATE_AS_INSTANT = (date, zone) -> {
+	public static final TemporalConverter<Date, Instant> JAVADATE_AS_INSTANT = (date, zone) -> {
 		if (date instanceof java.sql.Date) {
 			throw new TemporalConversionException(UNSUPPORTED_SQL_DATE_UNIT);
 		} else {
@@ -58,10 +58,10 @@ public class TemporalConverters {
 		}
 	};
 
-	public static TemporalConverter<Date, ZonedDateTime> JAVADATE_AS_ZONEDDATETIME = (date, zone) -> JAVADATE_AS_INSTANT.apply(date, zone).atZone(zone.orElse(ZoneId.systemDefault()));
-	public static TemporalConverter<Date, LocalDateTime> JAVADATE_AS_LOCALDATETIME = (date, zone) -> JAVADATE_AS_ZONEDDATETIME.apply(date, zone).toLocalDateTime();
+	public static final TemporalConverter<Date, ZonedDateTime> JAVADATE_AS_ZONEDDATETIME = (date, zone) -> JAVADATE_AS_INSTANT.apply(date, zone).atZone(zone.orElse(ZoneId.systemDefault()));
+	public static final TemporalConverter<Date, LocalDateTime> JAVADATE_AS_LOCALDATETIME = (date, zone) -> JAVADATE_AS_ZONEDDATETIME.apply(date, zone).toLocalDateTime();
 
-	public static TemporalConverter<Date, LocalDate> JAVADATE_AS_LOCALDATE = (date, zone) -> {
+	public static final TemporalConverter<Date, LocalDate> JAVADATE_AS_LOCALDATE = (date, zone) -> {
 		if (date instanceof java.sql.Date) {
 			return ((java.sql.Date) date).toLocalDate();
 		} else {
@@ -69,7 +69,7 @@ public class TemporalConverters {
 		}
 	};
 	
-	public static TemporalConverter<Date, TemporalAccessor> JAVADATE_AS_TEMPORAL = (date, zone) -> {
+	public static final TemporalConverter<Date, TemporalAccessor> JAVADATE_AS_TEMPORAL = (date, zone) -> {
 		if (date instanceof java.sql.Date) {
 			return JAVADATE_AS_LOCALDATE.apply(date, zone);
 		} else {
@@ -77,7 +77,7 @@ public class TemporalConverters {
 		}
 	};
 	
-    public static TemporalConverter<Date, java.sql.Date> JAVADATE_AS_SQLDATE = (date, zone) -> {
+    public static final TemporalConverter<Date, java.sql.Date> JAVADATE_AS_SQLDATE = (date, zone) -> {
         if (date instanceof java.sql.Date) {
             return (java.sql.Date) date;
         } else {
@@ -85,89 +85,90 @@ public class TemporalConverters {
         }
     };
 
-	public static TemporalConverter<Date, Date> JAVADATE_AS_JAVADATE = (date, zone) -> date;
-	public static TemporalConverter<Date, Year> JAVADATE_AS_YEAR = (date, zone) -> Year.from(JAVADATE_AS_LOCALDATE.apply(date, zone));
-	public static TemporalConverter<Date, Month> JAVADATE_AS_MONTH = (date, zone) -> JAVADATE_AS_LOCALDATE.apply(date, zone).getMonth();
-	public static TemporalConverter<Date, DayOfMonth> JAVADATE_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(JAVADATE_AS_LOCALDATE.apply(date, zone));
-	public static TemporalConverter<Date, DayOfWeek> JAVADATE_AS_DAYOFWEEK = (date, zone) -> JAVADATE_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
-	public static TemporalConverter<Date, Hour> JAVADATE_AS_HOUR = (date, zone) -> Hour.from(JAVADATE_AS_LOCALDATETIME.apply(date, zone));
-	public static TemporalConverter<Date, Minute> JAVADATE_AS_MINUTE = (date, zone) -> Minute.from(JAVADATE_AS_LOCALDATETIME.apply(date, zone));
-	public static TemporalConverter<Date, Second> JAVADATE_AS_SECOND = (date, zone) -> Second.from(JAVADATE_AS_LOCALDATETIME.apply(date, zone));
-	public static TemporalConverter<Date, Millisecond> JAVADATE_AS_MILLISECOND = (date, zone) -> Millisecond.from(JAVADATE_AS_INSTANT.apply(date, zone));
+	public static final TemporalConverter<Date, Date> JAVADATE_AS_JAVADATE = (date, zone) -> date;
+	public static final TemporalConverter<Date, Year> JAVADATE_AS_YEAR = (date, zone) -> Year.from(JAVADATE_AS_LOCALDATE.apply(date, zone));
+	public static final TemporalConverter<Date, Month> JAVADATE_AS_MONTH = (date, zone) -> JAVADATE_AS_LOCALDATE.apply(date, zone).getMonth();
+	public static final TemporalConverter<Date, DayOfMonth> JAVADATE_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(JAVADATE_AS_LOCALDATE.apply(date, zone));
+	public static final TemporalConverter<Date, DayOfWeek> JAVADATE_AS_DAYOFWEEK = (date, zone) -> JAVADATE_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
+	public static final TemporalConverter<Date, Hour> JAVADATE_AS_HOUR = (date, zone) -> Hour.from(JAVADATE_AS_LOCALDATETIME.apply(date, zone));
+	public static final TemporalConverter<Date, Minute> JAVADATE_AS_MINUTE = (date, zone) -> Minute.from(JAVADATE_AS_LOCALDATETIME.apply(date, zone));
+	public static final TemporalConverter<Date, Second> JAVADATE_AS_SECOND = (date, zone) -> Second.from(JAVADATE_AS_LOCALDATETIME.apply(date, zone));
+	public static final TemporalConverter<Date, Millisecond> JAVADATE_AS_MILLISECOND = (date, zone) -> Millisecond.from(JAVADATE_AS_INSTANT.apply(date, zone));
 
 	/**
 	 * LocalTime Converters
 	 */
-	public static TemporalConverter<LocalTime, LocalTime> LOCALTIME_AS_LOCALTIME = (time, zone) -> time;
-	public static TemporalConverter<LocalTime, Hour> LOCALTIME_AS_HOUR = (time, zone) -> Hour.from(time);
-	public static TemporalConverter<LocalTime, Minute> LOCALTIME_AS_MINUTE = (time, zone) -> Minute.from(time);
-	public static TemporalConverter<LocalTime, Second> LOCALTIME_AS_SECOND = (time, zone) -> Second.from(time);
+	public static final TemporalConverter<LocalTime, LocalTime> LOCALTIME_AS_LOCALTIME = (time, zone) -> time;
+	public static final TemporalConverter<LocalTime, Hour> LOCALTIME_AS_HOUR = (time, zone) -> Hour.from(time);
+	public static final TemporalConverter<LocalTime, Minute> LOCALTIME_AS_MINUTE = (time, zone) -> Minute.from(time);
+	public static final TemporalConverter<LocalTime, Second> LOCALTIME_AS_SECOND = (time, zone) -> Second.from(time);
 
 	/**
 	 * LocalDate Converters
 	 */
-	public static TemporalConverter<LocalDate, LocalDate> LOCALDATE_AS_LOCALDATE = (date, zone) -> date;
-	public static TemporalConverter<LocalDate, Year> LOCALDATE_AS_YEAR = (date, zone) -> Year.from(date);
-	public static TemporalConverter<LocalDate, Month> LOCALDATE_AS_MONTH = (date, zone) -> date.getMonth();
-	public static TemporalConverter<LocalDate, DayOfMonth> LOCALDATE_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(date);
-	public static TemporalConverter<LocalDate, DayOfWeek> LOCALDATE_AS_DAYOFWEEK = (date, zone) -> date.getDayOfWeek();
+	public static final TemporalConverter<LocalDate, LocalDate> LOCALDATE_AS_LOCALDATE = (date, zone) -> date;
+	public static final TemporalConverter<LocalDate, Year> LOCALDATE_AS_YEAR = (date, zone) -> Year.from(date);
+	public static final TemporalConverter<LocalDate, Month> LOCALDATE_AS_MONTH = (date, zone) -> date.getMonth();
+	public static final TemporalConverter<LocalDate, DayOfMonth> LOCALDATE_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(date);
+	public static final TemporalConverter<LocalDate, DayOfWeek> LOCALDATE_AS_DAYOFWEEK = (date, zone) -> date.getDayOfWeek();
 	
 	/**
 	 * LocalDateTime Converters
 	 */
-	public static TemporalConverter<LocalDateTime, LocalDateTime> LOCALDATETIME_AS_LOCALDATETIME = (date, zone) -> date;
-	public static TemporalConverter<LocalDateTime, LocalDate> LOCALDATETIME_AS_LOCALDATE = (date, zone) -> date.toLocalDate();
-	public static TemporalConverter<LocalDateTime, Year> LOCALDATETIME_AS_YEAR = (date, zone) -> Year.from(date);
-	public static TemporalConverter<LocalDateTime, Month> LOCALDATETIME_AS_MONTH = (date, zone) -> date.getMonth();
-	public static TemporalConverter<LocalDateTime, DayOfMonth> LOCALDATETIME_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(date);
-	public static TemporalConverter<LocalDateTime, DayOfWeek> LOCALDATETIME_AS_DAYOFWEEK = (date, zone) -> date.getDayOfWeek();
-	public static TemporalConverter<LocalDateTime, Hour> LOCALDATETIME_AS_HOUR = (date, zone) -> Hour.from(date);
-	public static TemporalConverter<LocalDateTime, Minute> LOCALDATETIME_AS_MINUTE = (date, zone) -> Minute.from(date);
-	public static TemporalConverter<LocalDateTime, Second> LOCALDATETIME_AS_SECOND = (date, zone) -> Second.from(date);
+	public static final TemporalConverter<LocalDateTime, LocalDateTime> LOCALDATETIME_AS_LOCALDATETIME = (date, zone) -> date;
+	public static final TemporalConverter<LocalDateTime, LocalDate> LOCALDATETIME_AS_LOCALDATE = (date, zone) -> date.toLocalDate();
+	public static final TemporalConverter<LocalDateTime, Year> LOCALDATETIME_AS_YEAR = (date, zone) -> Year.from(date);
+	public static final TemporalConverter<LocalDateTime, Month> LOCALDATETIME_AS_MONTH = (date, zone) -> date.getMonth();
+	public static final TemporalConverter<LocalDateTime, DayOfMonth> LOCALDATETIME_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(date);
+	public static final TemporalConverter<LocalDateTime, DayOfWeek> LOCALDATETIME_AS_DAYOFWEEK = (date, zone) -> date.getDayOfWeek();
+	public static final TemporalConverter<LocalDateTime, Hour> LOCALDATETIME_AS_HOUR = (date, zone) -> Hour.from(date);
+	public static final TemporalConverter<LocalDateTime, Minute> LOCALDATETIME_AS_MINUTE = (date, zone) -> Minute.from(date);
+	public static final TemporalConverter<LocalDateTime, Second> LOCALDATETIME_AS_SECOND = (date, zone) -> Second.from(date);
 
 	/**
 	 * ZonedDateTime Converters
 	 */
-	public static TemporalConverter<ZonedDateTime, ZonedDateTime> ZONEDDATETIME_AS_ZONEDDATETIME = (date, zone) -> zone.map(z -> date.withZoneSameInstant(z)).orElse(date);
-	public static TemporalConverter<ZonedDateTime, LocalDate> ZONEDDATETIME_AS_LOCALDATE = (date, zone) -> ZONEDDATETIME_AS_ZONEDDATETIME.apply(date, zone).toLocalDate();
-	public static TemporalConverter<ZonedDateTime, Year> ZONEDDATETIME_AS_YEAR = (date, zone) -> Year.from(ZONEDDATETIME_AS_LOCALDATE.apply(date, zone));
-	public static TemporalConverter<ZonedDateTime, Month> ZONEDDATETIME_AS_MONTH = (date, zone) -> ZONEDDATETIME_AS_LOCALDATE.apply(date, zone).getMonth();
-	public static TemporalConverter<ZonedDateTime, DayOfMonth> ZONEDDATETIME_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(ZONEDDATETIME_AS_LOCALDATE.apply(date, zone));
-	public static TemporalConverter<ZonedDateTime, DayOfWeek> ZONEDDATETIME_AS_DAYOFWEEK = (date, zone) -> ZONEDDATETIME_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
-	public static TemporalConverter<ZonedDateTime, Hour> ZONEDDATETIME_AS_HOUR = (date, zone) -> Hour.from(ZONEDDATETIME_AS_ZONEDDATETIME.apply(date, zone));
-	public static TemporalConverter<ZonedDateTime, Minute> ZONEDDATETIME_AS_MINUTE = (date, zone) -> Minute.from(ZONEDDATETIME_AS_ZONEDDATETIME.apply(date, zone));
-	public static TemporalConverter<ZonedDateTime, Second> ZONEDDATETIME_AS_SECOND = (date, zone) -> Second.from(ZONEDDATETIME_AS_ZONEDDATETIME.apply(date, zone));
+	public static final TemporalConverter<ZonedDateTime, ZonedDateTime> ZONEDDATETIME_AS_ZONEDDATETIME = (date, zone) -> zone.map(
+			date::withZoneSameInstant).orElse(date);
+	public static final TemporalConverter<ZonedDateTime, LocalDate> ZONEDDATETIME_AS_LOCALDATE = (date, zone) -> ZONEDDATETIME_AS_ZONEDDATETIME.apply(date, zone).toLocalDate();
+	public static final TemporalConverter<ZonedDateTime, Year> ZONEDDATETIME_AS_YEAR = (date, zone) -> Year.from(ZONEDDATETIME_AS_LOCALDATE.apply(date, zone));
+	public static final TemporalConverter<ZonedDateTime, Month> ZONEDDATETIME_AS_MONTH = (date, zone) -> ZONEDDATETIME_AS_LOCALDATE.apply(date, zone).getMonth();
+	public static final TemporalConverter<ZonedDateTime, DayOfMonth> ZONEDDATETIME_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(ZONEDDATETIME_AS_LOCALDATE.apply(date, zone));
+	public static final TemporalConverter<ZonedDateTime, DayOfWeek> ZONEDDATETIME_AS_DAYOFWEEK = (date, zone) -> ZONEDDATETIME_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
+	public static final TemporalConverter<ZonedDateTime, Hour> ZONEDDATETIME_AS_HOUR = (date, zone) -> Hour.from(ZONEDDATETIME_AS_ZONEDDATETIME.apply(date, zone));
+	public static final TemporalConverter<ZonedDateTime, Minute> ZONEDDATETIME_AS_MINUTE = (date, zone) -> Minute.from(ZONEDDATETIME_AS_ZONEDDATETIME.apply(date, zone));
+	public static final TemporalConverter<ZonedDateTime, Second> ZONEDDATETIME_AS_SECOND = (date, zone) -> Second.from(ZONEDDATETIME_AS_ZONEDDATETIME.apply(date, zone));
 	
 	/**
 	 * DayOfWeek Converters
 	 */
-	public static TemporalConverter<DayOfWeek, DayOfWeek> DAYOFWEEK_TO_DAYOFWEEK = (date, zone) -> date;
+	public static final TemporalConverter<DayOfWeek, DayOfWeek> DAYOFWEEK_TO_DAYOFWEEK = (date, zone) -> date;
 	
 	/**
      * {@link OffsetDateTime} Converters
      */
-	public static TemporalConverter<OffsetDateTime, OffsetDateTime> OFFSETDATETIME_AS_OFFSETDATETIME = (date, zone) -> zone.map(z -> date.withOffsetSameInstant(z.getRules().getOffset(date.toLocalDateTime()))).orElse(date);    
-    public static TemporalConverter<OffsetDateTime, LocalDate> OFFSETDATETIME_AS_LOCALDATE = (date, zone) -> OFFSETDATETIME_AS_OFFSETDATETIME.apply(date, zone).toLocalDate();
-    public static TemporalConverter<OffsetDateTime, Year> OFFSETDATETIME_AS_YEAR = (date, zone) -> Year.from(OFFSETDATETIME_AS_LOCALDATE.apply(date, zone));
-    public static TemporalConverter<OffsetDateTime, Month> OFFSETDATETIME_AS_MONTH = (date, zone) -> OFFSETDATETIME_AS_LOCALDATE.apply(date, zone).getMonth();
-    public static TemporalConverter<OffsetDateTime, DayOfMonth> OFFSETDATETIME_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(OFFSETDATETIME_AS_LOCALDATE.apply(date, zone));
-    public static TemporalConverter<OffsetDateTime, DayOfWeek> OFFSETDATETIME_AS_DAYOFWEEK = (date, zone) -> OFFSETDATETIME_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
-    public static TemporalConverter<OffsetDateTime, Hour> OFFSETDATETIME_AS_HOUR = (date, zone) -> Hour.from(OFFSETDATETIME_AS_OFFSETDATETIME.apply(date, zone));
-    public static TemporalConverter<OffsetDateTime, Minute> OFFSETDATETIME_AS_MINUTE = (date, zone) -> Minute.from(OFFSETDATETIME_AS_OFFSETDATETIME.apply(date, zone));
-    public static TemporalConverter<OffsetDateTime, Second> OFFSETDATETIME_AS_SECOND = (date, zone) -> Second.from(OFFSETDATETIME_AS_OFFSETDATETIME.apply(date, zone));    
+	public static final TemporalConverter<OffsetDateTime, OffsetDateTime> OFFSETDATETIME_AS_OFFSETDATETIME = (date, zone) -> zone.map(z -> date.withOffsetSameInstant(z.getRules().getOffset(date.toLocalDateTime()))).orElse(date);    
+    public static final TemporalConverter<OffsetDateTime, LocalDate> OFFSETDATETIME_AS_LOCALDATE = (date, zone) -> OFFSETDATETIME_AS_OFFSETDATETIME.apply(date, zone).toLocalDate();
+    public static final TemporalConverter<OffsetDateTime, Year> OFFSETDATETIME_AS_YEAR = (date, zone) -> Year.from(OFFSETDATETIME_AS_LOCALDATE.apply(date, zone));
+    public static final TemporalConverter<OffsetDateTime, Month> OFFSETDATETIME_AS_MONTH = (date, zone) -> OFFSETDATETIME_AS_LOCALDATE.apply(date, zone).getMonth();
+    public static final TemporalConverter<OffsetDateTime, DayOfMonth> OFFSETDATETIME_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(OFFSETDATETIME_AS_LOCALDATE.apply(date, zone));
+    public static final TemporalConverter<OffsetDateTime, DayOfWeek> OFFSETDATETIME_AS_DAYOFWEEK = (date, zone) -> OFFSETDATETIME_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
+    public static final TemporalConverter<OffsetDateTime, Hour> OFFSETDATETIME_AS_HOUR = (date, zone) -> Hour.from(OFFSETDATETIME_AS_OFFSETDATETIME.apply(date, zone));
+    public static final TemporalConverter<OffsetDateTime, Minute> OFFSETDATETIME_AS_MINUTE = (date, zone) -> Minute.from(OFFSETDATETIME_AS_OFFSETDATETIME.apply(date, zone));
+    public static final TemporalConverter<OffsetDateTime, Second> OFFSETDATETIME_AS_SECOND = (date, zone) -> Second.from(OFFSETDATETIME_AS_OFFSETDATETIME.apply(date, zone));    
     
     /**
      * Instant Converters
      */
-    public static TemporalConverter<Instant, Instant> INSTANT_AS_INSTANT = (date, zone) -> date;
-    public static TemporalConverter<Instant, ZonedDateTime> INSTANT_AS_ZONEDDATETIME = (date, zone) -> zone.map(z -> date.atZone(z)).orElse(date.atZone(ZoneId.systemDefault()));
-    public static TemporalConverter<Instant, LocalDate> INSTANT_AS_LOCALDATE = (date, zone) -> INSTANT_AS_ZONEDDATETIME.apply(date, zone).toLocalDate();
-    public static TemporalConverter<Instant, Year> INSTANT_AS_YEAR = (date, zone) -> Year.from(INSTANT_AS_LOCALDATE.apply(date, zone));
-    public static TemporalConverter<Instant, Month> INSTANT_AS_MONTH = (date, zone) -> INSTANT_AS_LOCALDATE.apply(date, zone).getMonth();
-    public static TemporalConverter<Instant, DayOfMonth> INSTANT_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(INSTANT_AS_LOCALDATE.apply(date, zone));
-    public static TemporalConverter<Instant, DayOfWeek> INSTANT_AS_DAYOFWEEK = (date, zone) -> INSTANT_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
-    public static TemporalConverter<Instant, Hour> INSTANT_AS_HOUR = (date, zone) -> Hour.from(INSTANT_AS_ZONEDDATETIME.apply(date, zone));
-    public static TemporalConverter<Instant, Minute> INSTANT_AS_MINUTE = (date, zone) -> Minute.from(INSTANT_AS_ZONEDDATETIME.apply(date, zone));
-    public static TemporalConverter<Instant, Second> INSTANT_AS_SECOND = (date, zone) -> Second.from(INSTANT_AS_ZONEDDATETIME.apply(date, zone));
+    public static final TemporalConverter<Instant, Instant> INSTANT_AS_INSTANT = (date, zone) -> date;
+    public static final TemporalConverter<Instant, ZonedDateTime> INSTANT_AS_ZONEDDATETIME = (date, zone) -> zone.map(date::atZone).orElse(date.atZone(ZoneId.systemDefault()));
+    public static final TemporalConverter<Instant, LocalDate> INSTANT_AS_LOCALDATE = (date, zone) -> INSTANT_AS_ZONEDDATETIME.apply(date, zone).toLocalDate();
+    public static final TemporalConverter<Instant, Year> INSTANT_AS_YEAR = (date, zone) -> Year.from(INSTANT_AS_LOCALDATE.apply(date, zone));
+    public static final TemporalConverter<Instant, Month> INSTANT_AS_MONTH = (date, zone) -> INSTANT_AS_LOCALDATE.apply(date, zone).getMonth();
+    public static final TemporalConverter<Instant, DayOfMonth> INSTANT_AS_DAYOFMONTH = (date, zone) -> DayOfMonth.from(INSTANT_AS_LOCALDATE.apply(date, zone));
+    public static final TemporalConverter<Instant, DayOfWeek> INSTANT_AS_DAYOFWEEK = (date, zone) -> INSTANT_AS_LOCALDATE.apply(date, zone).getDayOfWeek();
+    public static final TemporalConverter<Instant, Hour> INSTANT_AS_HOUR = (date, zone) -> Hour.from(INSTANT_AS_ZONEDDATETIME.apply(date, zone));
+    public static final TemporalConverter<Instant, Minute> INSTANT_AS_MINUTE = (date, zone) -> Minute.from(INSTANT_AS_ZONEDDATETIME.apply(date, zone));
+    public static final TemporalConverter<Instant, Second> INSTANT_AS_SECOND = (date, zone) -> Second.from(INSTANT_AS_ZONEDDATETIME.apply(date, zone));
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/TemporalMatcher.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/TemporalMatcher.java
@@ -7,7 +7,7 @@ import java.util.Locale;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
- * Abstract {@link org.hamcrest.Matcher<T>} for temporal objects allowing for time zone manipulation.
+ * Abstract {@link org.hamcrest.Matcher} for temporal objects allowing for time zone manipulation.
  *
  * @param <T> the type of objects handled by this matcher
  *


### PR DESCRIPTION
The current version of hamcrest date is depending on the hamcrest version 1.3. It is old dated and we need to use the newer version as 2.2.
